### PR TITLE
Adding option to specify resolved bug ids

### DIFF
--- a/RBTools/RBTools.Domain/Options/Post/Fields/BugsClosed.cs
+++ b/RBTools/RBTools.Domain/Options/Post/Fields/BugsClosed.cs
@@ -6,7 +6,7 @@ namespace RBTools.Domain.Options.Post.Fields
 {
     public class BugsClosed : RbtOption, IHasLongForm, IHasValue
     {
-        public string LongForm { get; } = "--bugs-closed";
+        public string LongForm { get; } = "bugs-closed";
         public string Value { get; }
 
         public BugsClosed(IEnumerable<string> bugIds)

--- a/RBTools/RBTools.Domain/Options/Post/Posting/Update.cs
+++ b/RBTools/RBTools.Domain/Options/Post/Posting/Update.cs
@@ -2,7 +2,7 @@
 {
     public class Update : RbtOption, IHasLongForm, IHasShortForm
     {
-        public string LongForm { get; } = "-update";
+        public string LongForm { get; } = "update";
         public string ShortForm { get; } = "u";
     }
 }

--- a/RBTools/RBTools.UI.Wpf/SeedWork/Mapping/Mapper.cs
+++ b/RBTools/RBTools.UI.Wpf/SeedWork/Mapping/Mapper.cs
@@ -29,6 +29,8 @@ namespace RBTools.UI.Wpf.SeedWork.Mapping
                 dto.Repository = vm.Settings.RepositoryName;
             if (!string.IsNullOrWhiteSpace(vm.Settings.RepositoryUrl))
                 dto.Server = vm.Settings.RepositoryUrl;
+            if (!string.IsNullOrWhiteSpace(vm.BugIds))
+                dto.BugIds = vm.BugIds.Split(',', StringSplitOptions.RemoveEmptyEntries);
 
             if (vm.ReviewType.IsUpdate)
             {

--- a/RBTools/RBTools.UI.Wpf/ViewModels/SendViewModel.cs
+++ b/RBTools/RBTools.UI.Wpf/ViewModels/SendViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Input;
 using RBTools.Application;
 using RBTools.Application.Communication.DTO;
@@ -17,6 +19,7 @@ namespace RBTools.UI.Wpf.ViewModels
         private string _updateDescription;
         private ReviewType _reviewType;
         private string _revision;
+        private string _bugIds;
 
         public SendViewModel(Settings settings, PostCommandIssuer issuer)
         {
@@ -28,7 +31,6 @@ namespace RBTools.UI.Wpf.ViewModels
         public Settings Settings { get; }
         public PostCommandIssuer Issuer { get; }
         public ReviewType[] ReviewTypes { get; } = new[] { ReviewType.PreCommitNew, ReviewType.PreCommitUpdate, ReviewType.PostCommitNew, ReviewType.PostCommitUpdate };
-
         public ICommand PostCommand => new RelayCommand<RbtPostDto>(o => Issuer.Issue(Mapper.CreateDto(this)));
 
         public string Summary
@@ -105,6 +107,17 @@ namespace RBTools.UI.Wpf.ViewModels
             {
                 if (_updateDescription == value) return;
                 _updateDescription = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string BugIds
+        {
+            get => _bugIds;
+            set
+            {
+                if (_bugIds == value) return;
+                _bugIds = value;
                 OnPropertyChanged();
             }
         }

--- a/RBTools/RBTools.UI.Wpf/Views/SendView.xaml
+++ b/RBTools/RBTools.UI.Wpf/Views/SendView.xaml
@@ -61,7 +61,7 @@
               Margin="10,0,0,0">
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
+                <RowDefinition Height="0.5*"/>
                 <RowDefinition Height="*" MaxHeight="300"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -104,7 +104,8 @@
                 </GroupBox>
             </Grid>
 
-            <DockPanel Grid.Row="1">
+            <DockPanel Grid.Row="1"
+                       LastChildFill="True">
                 <ComboBox ui:ControlHelper.Header="Review type"
                           ItemsSource="{Binding ReviewTypes, Mode=OneTime}"
                           SelectedItem="{Binding ReviewType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -123,6 +124,11 @@
                          Text="{Binding ReviewId}"
                          IsEnabled="{Binding ReviewType, Converter={StaticResource IsUpdateReviewTypeConverter}}"
                          DockPanel.Dock="Top"/>
+                <TextBox ui:ControlHelper.Header="Bug ids"
+                         ui:ControlHelper.PlaceholderText="Comma separated bug ids"
+                         Style="{StaticResource OneLineTextBox}"
+                         Text="{Binding BugIds, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         DockPanel.Dock="Bottom"/>
                 <TextBox ui:ControlHelper.Header="Changes"
                          ui:ControlHelper.PlaceholderText="What has been updated"
                          Style="{StaticResource MultiLineTextBox}"
@@ -140,10 +146,6 @@
                 <CheckBox Content="Publish"
                           ToolTip="When selected will publish review right after posting"
                           IsChecked="{Binding Settings.Publish, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-
-                <CheckBox Content="SVN show copies as adds"
-                          ToolTip="When selected will treat copied/moved files as new ones"
-                          IsChecked="{Binding Settings.SvnShowCopiesAsAdds, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
             </StackPanel>
 
             <Button Grid.Row="3"


### PR DESCRIPTION
Adding option to specify resolved bug ids & removing svn-show-copies-as-adds from main send view as if working on svn this option should probably always be selected anyway and there is no need to bother user with having this visible